### PR TITLE
seed the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-## JBang Catalog
+## HanSolo's JBang Catalog
+
+This catalog has a selection of java based applications from HanSolo.
+
+Use [jbang](https://jbang.dev/downloads) to run or install them.
+
+Examples:
+```
+## see list of availabl aliases
+$ jbang alias list hansolo
+
+## run jarkanoid
+$ jbang jarkanoid@hansolo
+
+## install and discocli as an app
+$ jbang app install discocli@hansolo
+$ discocli
+```
+

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,34 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "jarkanoid": {
+      "script-ref": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.7/jarkanoid-mac-x64-17.0.7.jar",
+      "dependencies": [
+        "org.openjfx:javafx-controls:18.0.2:${os.detected.jfxname}",
+        "org.openjfx:javafx-media:18.0.2:${os.detected.jfxname}"
+      ],
+      "java": "17+"
+    },
+    "jdkmon": {
+      "script-ref": "https://github.com/HanSolo/JDKMon/releases/download/17.0.45/JDKMon-17.0.45-linux-x64.jar",
+      "dependencies": [
+        "org.openjfx:javafx-controls:18.0.2:${os.detected.jfxname}",
+        "org.openjfx:javafx-media:18.0.2:${os.detected.jfxname}"
+      ],
+      "java": "17+"
+    },
+    "jcpu": {
+      "script-ref": "https://github.com/HanSolo/jcpu/releases/download/17.0.0/jcpu-macos-x64-17.0.0.jar",
+      "dependencies": [
+        "org.openjfx:javafx-controls:18.0.2:${os.detected.jfxname}",
+        "org.openjfx:javafx-media:18.0.2:${os.detected.jfxname}"
+      ],
+      "java": "17+"
+    },
+    "discocli": {
+      "script-ref": "https://github.com/HanSolo/discocli/releases/download/17.0.15/discocli-17.0.15-fat.jar",
+      "java": "17+"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
seeded the catalog with jarkanoid, jdkmon, jcpu and discocli. Tried spacefx too but seem to be built with java 16 preview features thus can't run it on my mac to try it out as only Java 11 and 17 available for M1.

note - I'm using absolute URLs here as all the released artifacts has absolute version numbers in them.

It would be nicer if the jars was published in maven central or there was a version-less jar available under releases.
Since then we could use i.e. `eu.hansolo.spacefx:spacefx:RELEASE` to get latest maven release or `https://github.com/HanSolo/jcpu/releases/download/latest/jcpu-macos.jar` which will automatically get the latest github release.

just a suggestion - since without it you would need/want to bump the versions manually in this catalog.